### PR TITLE
Fix #17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_neo4j
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_libsodium
   - sudo sh -c 'echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  - ifconfig
 script:
   - "$TRAVIS_BUILD_DIR/discovery_agents/netconfig"
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_script:
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_neo4j
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_libsodium
   - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-  - ifconfig
 script:
   - "$TRAVIS_BUILD_DIR/discovery_agents/netconfig"
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 before_script:
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_neo4j
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_libsodium
+  - sudo sh -c 'echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 script:
   - "$TRAVIS_BUILD_DIR/discovery_agents/netconfig"
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_neo4j
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_libsodium
 script:
+  - "$TRAVIS_BUILD_DIR/discovery_agents/netconfig"
   - cd $TRAVIS_BUILD_DIR
   - cd ..
   - mkdir root_of_binary_tree
@@ -27,6 +28,4 @@ script:
   - sudo assimcli genkeys
   - cd $TRAVIS_BUILD_DIR/cma
   - sudo testify -v tests
-  - "$TRAVIS_BUILD_DIR/discovery_agents/netconfig"
   - cd $TRAVIS_BUILD_DIR
-  - "../root_of_binary_tree/testcode/pinger ::1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 before_script:
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_neo4j
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_libsodium
-  - sudo sh -c 'echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
+  - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
   - ifconfig
 script:
   - "$TRAVIS_BUILD_DIR/discovery_agents/netconfig"


### PR DESCRIPTION
Removes pinger since it's included in testify tests.
Moves netconfig discovery to before build step.