### PR TITLE
Issue #19: Introduce UNWARN event/add event sending to best practices

### DIFF
--- a/cma/assimevent.py
+++ b/cma/assimevent.py
@@ -39,14 +39,16 @@ class AssimEvent(object):
     OBJUP = 1       # Object status is now up
     OBJDOWN = 2     # Object status is now down
     OBJWARN = 3     # Object status is now in a warning state
-    OBJUPDATE = 4   # Object was updated
-    OBJDELETE = 5   # Object is about to be deleted
+    OBJUNWARN = 4   # Object status has exited a warning state
+    OBJUPDATE = 5   # Object was updated
+    OBJDELETE = 6   # Object is about to be deleted
 
     eventtypenames = {
         CREATEOBJ:  'create',
         OBJUP:      'up',
         OBJDOWN:    'down',
         OBJWARN:    'warn',
+        OBJUNWARN:  'unwarn',
         OBJUPDATE:  'update',
         OBJDELETE:  'delete'
     }


### PR DESCRIPTION

This commit introduces a new event type called an UNWARN which will signal that
a best practices failure has been resolved. It also reorders the numbers for
the events so WARN and UNWARN are close together. The UNWARN events will be
send when when a failed best practice is resolved to the pass, ignore, or NA
state. Likewise the event sending code will send WARN events when a best
practices failure is generated after the rule was not previously detected
(none) or  detected as a pass, ignore, or NA.