### PR TITLE
fix: clientlib: don't limit getaddrinfo to dgram

### DIFF
--- a/clientlib/netaddr.c
+++ b/clientlib/netaddr.c
@@ -1038,7 +1038,6 @@ netaddr_dns_new(const char * sysname_or_addr)	//< System name/address
 	}
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_DGRAM;
 	rc =  getaddrinfo(sysname, service, &hints, &sysinfo);
 	if (0 != rc) {
 		DEBUGMSG("%s.%d: Could not resolve %s - reason: %s"


### PR DESCRIPTION
Let getaddrinfo find any net address. gettaddrinfo(3) says:

       ai_socktype This field specifies the preferred socket type, for example
                   SOCK_STREAM  or  SOCK_DGRAM.   Specifying  0  in this field
                   indicates that socket addresses of any type can be returned
                   by getaddrinfo().

