### PR TITLE
use neo4j docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,5 @@ script:
   - sudo /etc/init.d/nanoprobe stop
   - sudo /etc/init.d/cma stop
   - sudo assimcli genkeys
-  - grep -n dbms.security /var/lib/neo4j/conf/neo4j-server.properties /dev/null
   - make tests # contains sudo commands
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,15 @@ language: c
 env:
   global:
     - BROKENDNS=1
-
+services:
+  - docker
 install:
   - sudo apt-get update -qq
   - sudo apt-get install -y python-flask doxygen valgrind libpcap-dev python-pip cmake build-essential pkg-config libglib2.0-dev resource-agents python-netaddr python-demjson openjdk-7-jre
   - sudo -H pip install --upgrade pip
   - sudo -H pip install ctypesgen flask getent py2neo==2.0.8 pytest
 before_script:
-  - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_neo4j
+  - docker run -d --publish=7474:7474 --publish=7687:7687 --volume=$HOME/neo4j/data:/data neo4j:2.3.4
   - sudo $TRAVIS_BUILD_DIR/buildtools/ci/install_libsodium
   - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 script:


### PR DESCRIPTION
since we have issues installing neo4j with apt-get, i used the docker feature in travis (https://docs.travis-ci.com/user/docker/) grabbing the official neo4j docker images (https://hub.docker.com/_/neo4j/) and specified version 2.3.4.