### PR TITLE
support for vagrant in systemtests

### DIFF
--- a/cma/systemtests/README.md
+++ b/cma/systemtests/README.md
@@ -1,0 +1,61 @@
+System testing
+--------------
+
+This is the system testing machinery, based on VM/container
+systems.
+
+Either docker or vagrant setup is necessary to run it.
+
+It is also necessary to configure your host's syslog for remote
+logging. For instance, for rsyslog, one can use something like
+this:
+
+	module(load="imtcp")
+	input(type="imtcp" port="514")
+
+	if $fromhost-ip startswith '172.17.' or $HOSTNAME == 'cma' or $HOSTNAME startswith 'nanoprobe' then {
+		/var/log/assim.log
+		stop
+	}
+
+Just put that in /etc/rsyslog.d/assim.conf and you should be OK.
+Make sure that the user with which you run tests have read access
+to the log file. Or just do this:
+
+	$ sudo chmod 644 /var/log/assim.log
+
+The script to start the tests is runtests.sh. Example use:
+
+	$ sh runtests.sh -l /var/log/assim.log -m vagrant 20
+
+Docker
+------
+
+The tests use docker containers by default. The tests can be used
+without any further configuration after successfully building
+packages in the docker directory which is at the top of the
+project.
+
+Vagrant
+-------
+
+The vagrant's Vagrantfile as well as provisioning shell scripts
+are in the vagrant directory. The base box is Debian stretch. We
+used this one:
+
+https://app.vagrantup.com/debian/boxes/stretch64
+
+Before running the tests, copy the cma, nanoprobe, and libsodium
+debian packages to the vagrant directory. They are going to be
+installed in VMs from that directory. By default, vagrant shares
+it with the VMs.
+
+The VMs are going to be "cma" (for the cma) and "nanoprobe%n"
+(for nanoprobes) where "%n" stands for a nanoprobe number (a
+small integer). The nanoprobe VMs count starts at 1.
+
+To use other boxes/distributions please modify the Vagrantfile
+and the provisioning scripts accordingly. For other Debian based
+distributions such as Ubuntu, it should be enough just to modify
+the base box name. It is out of scope for this document to
+describe vagrant, but it should not be very difficult.

--- a/cma/systemtests/assimtest.py
+++ b/cma/systemtests/assimtest.py
@@ -154,6 +154,27 @@ def testmain(logname):
     ,   help
     =   'Log file where syslog sends messages')
 
+    parser.add_option('-m', '--mgmtsystem'
+    ,   action='store'
+    ,   default="docker"
+    ,   dest='mgmtsystem'
+    ,   help
+    =   'Management system to use for VMs/containers (docker or vagrant)')
+
+    parser.add_option('-C', '--cmaimage'
+    ,   action='store'
+    ,   default="assimilation/build-stretch"
+    ,   dest='cmaimage'
+    ,   help
+    =   'VM/container image to use for cma')
+
+    parser.add_option('-N', '--nanoimages'
+    ,   action='store'
+    ,   default="assimilation/build-stretch"
+    ,   dest='nanoimages'
+    ,   help
+    =   'VM/container images to use for nanoprobes (use space as a separator)')
+
     (opts, args) = parser.parse_args()
     opts.cmadebug = int(opts.cmadebug)
     opts.nanodebug = int(opts.nanodebug)
@@ -190,9 +211,18 @@ def testmain(logname):
     else:
         testset = [test for test in AssimSysTest.testset]
 
+    # Use cmaimage for nanoimages as default
+    if len(opts.nanoimages) > 0:
+        nanoimages=opts.nanoimages.split()
+    else:
+        nanoimages=[opts.cmaimage]
+
     # Set up the test environment as requested
     env, store = AssimSysTest.initenviron(opts.logname, maxdrones
+    ,   opts.mgmtsystem
     ,   (opts.cmadebug > 0 or opts.nanodebug > 0)
+    ,   cmaimage=opts.cmaimage
+    ,   nanoimages=nanoimages
     ,   cmadebug=opts.cmadebug, nanodebug=opts.nanodebug)
 
     logit('CMA:  %s %15s %6d %s' % (env.cma.hostname, env.cma.ipaddr, env.cma.pid, env.cma.name))

--- a/cma/systemtests/assimtest.py
+++ b/cma/systemtests/assimtest.py
@@ -147,6 +147,13 @@ def testmain(logname):
     ,   help
     =   'Random seed - a comma-separated list of 8 integers between 0 and 255 - from previous run')
 
+    parser.add_option('-l', '--logname'
+    ,   action='store'
+    ,   default=logname
+    ,   dest='logname'
+    ,   help
+    =   'Log file where syslog sends messages')
+
     (opts, args) = parser.parse_args()
     opts.cmadebug = int(opts.cmadebug)
     opts.nanodebug = int(opts.nanodebug)
@@ -184,7 +191,7 @@ def testmain(logname):
         testset = [test for test in AssimSysTest.testset]
 
     # Set up the test environment as requested
-    env, store = AssimSysTest.initenviron(logname, maxdrones
+    env, store = AssimSysTest.initenviron(opts.logname, maxdrones
     ,   (opts.cmadebug > 0 or opts.nanodebug > 0)
     ,   cmadebug=opts.cmadebug, nanodebug=opts.nanodebug)
 
@@ -194,7 +201,7 @@ def testmain(logname):
 
     print '\n'
     logit('STARTING %d tests on %d nanoprobes + CMA' % (itercount, maxdrones))
-    return perform_tests(testset, env, store, itercount, logname)
+    return perform_tests(testset, env, store, itercount, opts.logname)
 
 
 sys.stdout = sys.stderr # Get rid of that nasty buffering...

--- a/cma/systemtests/querytest.py
+++ b/cma/systemtests/querytest.py
@@ -124,7 +124,7 @@ class QueryTest(object):
 if __name__ == "__main__":
     # pylint: disable=C0411,C0413,E0401
     import os
-    from docker import SystemTestEnvironment
+    from sysmgmt import SystemTestEnvironment
     sys.path.append('..')
     import graphnodes as GN
     from store import Store

--- a/cma/systemtests/runtests.sh
+++ b/cma/systemtests/runtests.sh
@@ -30,10 +30,11 @@ mkdir $dirname
 LOGMSG="STARTING ASSIMILATION TESTS in $dirname with ARGS: $@"
 LOGNAME="$dirname/testlog.txt"
 SYSLOGTAIL="$dirname/syslog"
-SYSLOG=/var/log/syslog
 echo $LOGMSG > $LOGNAME
 echo '# vim: syntax=messages' > $SYSLOGTAIL
 logger -s "$LOGMSG" 2>$LOGNAME
+SYSLOG=`echo $@ | sed 's/.*-l  *\([^ ]*\).*/\1/'`
+: ${SYSLOG="/var/log/syslog"}
 tail -1f $SYSLOG >> $SYSLOGTAIL &
 syslogpid=$!
 sudo time python assimtest.py "$@" >>$LOGNAME 2>&1 &

--- a/cma/systemtests/runtests.sh
+++ b/cma/systemtests/runtests.sh
@@ -24,6 +24,10 @@
 #
 #   Script to run system tests and save results and syslog into a unique directory.
 #
+if [ $# -eq 0 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    python assimtest.py
+    exit
+fi
 dirname=$(date --iso-8601=seconds)
 echo $name
 mkdir $dirname
@@ -37,7 +41,7 @@ SYSLOG=`echo $@ | sed 's/.*-l  *\([^ ]*\).*/\1/'`
 : ${SYSLOG="/var/log/syslog"}
 tail -1f $SYSLOG >> $SYSLOGTAIL &
 syslogpid=$!
-sudo time python assimtest.py "$@" >>$LOGNAME 2>&1 &
+time python assimtest.py "$@" >>$LOGNAME 2>&1 &
 testpid=$!
 tail -f $LOGNAME &
 tailpid=$!

--- a/cma/systemtests/testcases.py
+++ b/cma/systemtests/testcases.py
@@ -32,7 +32,7 @@ sys.path.append('..')
 sys.path.append('.')
 from logwatcher import LogWatcher
 from querytest import QueryTest
-from docker import SystemTestEnvironment, TestSystem
+from sysmgmt import SystemTestEnvironment, TestSystem
 # pylint: disable=E0401
 import graphnodes as GN
 from cmainit import CMAinit

--- a/cma/systemtests/testcases.py
+++ b/cma/systemtests/testcases.py
@@ -195,11 +195,12 @@ class AssimSysTest(object):
     @staticmethod
     # too many local variables
     # pylint: disable=R0914
-    def initenviron(logname, maxdrones, debug=False, timeout=90, nanodebug=0, cmadebug=0):
+    def initenviron(logname, maxdrones, mgmtsystem, debug=False, cmaimage='', nanoimages=[], timeout=90, nanodebug=0, cmadebug=0):
         'Initialize the test environment.'
         logwatch = LogWatcher(logname, [], timeout, returnonlymatch=True, debug=debug)
         logwatch.setwatch()
-        sysenv = SystemTestEnvironment(logname, maxdrones, nanodebug=nanodebug, cmadebug=cmadebug)
+    
+        sysenv = SystemTestEnvironment(logname, maxdrones, mgmtsystem, cmaimage=cmaimage, nanoimages=nanoimages, nanodebug=nanodebug, cmadebug=cmadebug)
         CMAinit(None, host=str(sysenv.cma.ipaddr), readonly=True,
                 neologin=SystemTestEnvironment.NEO4JLOGIN, neopass=SystemTestEnvironment.NEO4JPASS)
         url = 'http://%s:%d/db/data/' % (sysenv.cma.ipaddr, 7474)

--- a/cma/systemtests/vagrant/Vagrantfile
+++ b/cma/systemtests/vagrant/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+if ENV['NUM_NANOPROBES']
+	N = ENV['NUM_NANOPROBES'].to_i
+else
+	N = 1
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "debian/stretch64"
+  config.vm.box_check_update = FALSE
+  #config.vm.network "private_network", type: "dhcp"
+  config.apt_proxy.http = "http://10.0.2.2:3142"
+  config.apt_proxy.https = "DIRECT"
+  config.vm.define "cma" do |cma|
+	  cma.vm.hostname = "cma"
+	  cma.vm.provision :shell, path: "install_nanoprobe"
+	  cma.vm.provision :shell, path: "install_cma"
+  end
+  (1..N).each do |i|
+	  config.vm.define "nanoprobe#{i}" do |nanoprobe|
+		  nanoprobe.vm.hostname = "nanoprobe#{i}"
+		  nanoprobe.vm.provision :shell, path: "install_nanoprobe"
+	  end
+  end
+end

--- a/cma/systemtests/vagrant/install_cma
+++ b/cma/systemtests/vagrant/install_cma
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+
+NEOVERS=3.0.0
+neoversion=stable
+echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+apt-get -y update
+apt-get -y install --no-install-recommends gnupg wget python-setuptools python-pip python-netaddr lsb-release iproute2 adduser
+pip install 'py2neo==2.0.8' getent
+wget -q -O - http://debian.neo4j.org/neotechnology.gpg.key | apt-key add - 
+echo "deb http://debian.neo4j.org/repo ${neoversion}/" > /etc/apt/sources.list.d/neo4j.list
+apt-get -y update
+apt-get -y install --no-install-recommends neo4j=$NEOVERS
+apt-get -y install --no-install-recommends /vagrant/assimilation-cma_*.deb

--- a/cma/systemtests/vagrant/install_nanoprobe
+++ b/cma/systemtests/vagrant/install_nanoprobe
@@ -1,0 +1,10 @@
+#!/bin/sh
+#
+
+apt-get -y update
+apt-get -y install --no-install-recommends rsyslog net-tools tcpdump
+apt-get -y install --no-install-recommends /vagrant/libsodium_*.deb /vagrant/assimilation-nanoprobe_*.deb
+
+# copy the key
+mkdir -p ~root/.ssh
+cp ~vagrant/.ssh/authorized_keys ~root/.ssh


### PR DESCRIPTION
Apart from vagrant support, there are also 4 new options to assimtest.py. Some refactoring necessary to add support for another management system. Removed "sudo" from runtests.sh (one can run this as a regular user anyway).