### PR TITLE
dev: systemtests: fix invoking tcpdump and add the -1 option

### DIFF
--- a/cma/systemtests/assimtest.py
+++ b/cma/systemtests/assimtest.py
@@ -182,6 +182,14 @@ def testmain(logname):
     ,   help
     =   'The vagrant directory (only valid with -m vagrant)')
 
+    parser.add_option('-1', '--onedrone'
+    ,   action='store_true'
+    ,   default=False
+    ,   dest='onedrone'
+    ,   help
+    =   '''Run tests with just one drone and without
+        nanoprobe on the CMA system.''')
+
     (opts, args) = parser.parse_args()
     opts.cmadebug = int(opts.cmadebug)
     opts.nanodebug = int(opts.nanodebug)
@@ -195,6 +203,9 @@ def testmain(logname):
     else:
         parser.parse_args(['--help'])
         return 1
+
+    if opts.onedrone:
+        maxdrones = 1
 
     if opts.seed is None:
         # Prepare Random number generator

--- a/cma/systemtests/sysmgmt.py
+++ b/cma/systemtests/sysmgmt.py
@@ -480,8 +480,8 @@ class SystemTestEnvironment(object):
         )
 
         if tcpdump:
-            nano.runinimage(('/usr/sbin/tcpdump -C 10 -U -s 1024 '
-            '-w /tmp/tcpdump udp port 1984 &',))
+            nano.runinimage(('dtach -n tcpdump.sock /usr/sbin/tcpdump -C 10 -U -s 1024 '
+            '-w /tmp/tcpdump udp port 1984 >/dev/null </dev/null 2>&1',))
         print >> sys.stderr, ('NANOPROBE CONFIG [%s] %s' % (nano.hostname, nano.name))
         nano.runinimage(('rm', '-f', '/etc/default/nanoprobe'))
         for j in range(0, len(lines)):
@@ -513,7 +513,8 @@ class SystemTestEnvironment(object):
         self.set_cmaconfig(debug=cmadebug)
         self.cma.startservice(SystemTestEnvironment.CMASERVICE)
         self.set_nanoconfig(self.cma, debug=nanodebug)
-        self.cma.startservice(SystemTestEnvironment.NANOSERVICE)
+        if self.nanocount > 1:
+            self.cma.startservice(SystemTestEnvironment.NANOSERVICE)
         return self.cma
 
     def spawnnanoprobe(self, debug=0):

--- a/cma/systemtests/vagrant/install_nanoprobe
+++ b/cma/systemtests/vagrant/install_nanoprobe
@@ -2,5 +2,5 @@
 #
 
 apt-get -y update
-apt-get -y install --no-install-recommends rsyslog net-tools tcpdump
+apt-get -y install --no-install-recommends rsyslog net-tools dtach tcpdump
 apt-get -y install --no-install-recommends /vagrant/libsodium_*.deb /vagrant/assimilation-nanoprobe_*.deb


### PR DESCRIPTION
tcpdump gets invoked with dtach now, the fabric thing is somewhat
finicky with ttys.

-1: means run with just one drone and no nanoprobe at the cma. Useful
for very basic testing.