### PR TITLE
Medium: clientlib: don't set nextrexmit time on ACK

### DIFF
--- a/clientlib/fsprotocol.c
+++ b/clientlib/fsprotocol.c
@@ -1170,7 +1170,6 @@ _fsprotocol_receive(FsProtocol* self			///< Self pointer
 					_fsprotocol_fsa(fspe, FSPROTO_OUTALLDONE, fs);
 				}
 			}else{
-				fspe->nextrexmit = now + self->rexmit_interval;
 				fspe->acktimeout = now + self->acktimeout;
 				TRYXMIT(fspe);
 			}


### PR DESCRIPTION
Moving nextrexmit time into future on receiving an ACK seems
unwarranted. On ACK receive, the frameset is anyway going to be removed
from the queue. If there are more framesets in the queue, they should be
then sent at the time which has been set when a previous (now probably
acknowledged) frameset was sent. That way we get packets going out at a
rate of 1 per rexmit_interval (currently set to 2 seconds). Otherwise,
the rate appears to be roughly halfed (as actually observed). If we want
a slower rate, then perhaps the FSPROTO_REXMITINTERVAL should be updated
accordingly.